### PR TITLE
Switching from Travis-CI to GitHub actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,6 @@ Dockerfile
 .dockerignore
 .gitignore
 .git
+.github
 .editorconfig
 .jshintrc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    
+    - name: Install dependencies
+      run: npm ci
+    
+    - name: Run tests
+      run: npm test
+    
+    - name: Linting
+      run: npm run lint 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-  - 12


### PR DESCRIPTION
Travis-CI changed their payment model and stopped many of our build. Because of this we are switching all MediathekView CI builds from Travis-CI to GitHub Actions.