### PR TITLE
fix: ZDF api token retrieval

### DIFF
--- a/downloader/zdf-downloader.js
+++ b/downloader/zdf-downloader.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import moment from "moment-timezone";
 import Show from "../models/Show.js";
 
-const apiTokenRegex = new RegExp("apiToken[\\s\:\"\"]*([\\w\-\.]{40,})");
+const apiTokenRegex = new RegExp("videoToken[\\\\s\:\"\{]*apiToken[\\\\s\:\"]*([\\w\-\.]{40,})");
 const indexUrl = "https://www.zdf.de/live-tv";
 const baseUrl = "https://api.zdf.de/cmdm/epg/broadcasts?limit=1&page=1&order=desc";
 const headers = {


### PR DESCRIPTION
With the recent update of the ZDF mediathek the regex for retrieving the API token no longer works.

The `videoToken` part is included because of the `appToken` to ensure we only have one match, in case the order in the `tokens` object changes. This however should not be the case and can probably be removed if desired.

